### PR TITLE
GitHub Action, deployment to PyPI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - main
-      
+
 permissions:
   contents: read
 
@@ -29,6 +29,6 @@ jobs:
           python -m build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@release/v1.8.14
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: prep action
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+# More information on this workflow: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Deploy to PyPI
+
+on:
+  push:
+    branches:
+      - main
+      
+permissions:
+  contents: read
+
+jobs:
+
+  build_and_deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: prep action
+        uses: actions/checkout@v3
+
+      - name: setup Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+
+      - name: Build a binary wheel
+        run: |
+          pip install --upgrade build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## first attempt at automatic deployment from GitHub to PyPI
- Per issue #1 
- This will build a wheel, then upload it to PyPI
- The action will run when there is a merge to the `main` branch
- To successfully upload to PyPI, you must increment the `version` number in the `pyproject.toml` file. If you merge to main without incrementing the version, the action will throw an error like this: 
![ss](https://github.com/waifuvault/waifuVault-python-api/assets/107364642/8149c949-3e03-48ff-867b-8be157062bd9)

- Notice that I did not increment the version with this PR. If you review this and find it acceptable, I can create another commit to increment the version, to test the action, or you can do that separately after merging.
- I think I did this right but I'm not an expert so it needs to be tested!

