### PR TITLE
upgrade GH Action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: filter changes
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v3
         id: changes
         with:
           filters: |


### PR DESCRIPTION
Upgrade version of [Paths Changes Filter](https://github.com/dorny/paths-filter) helper GH Action
- previous version uses deprecated version of Node (16)
- [v3](https://github.com/dorny/paths-filter/releases/tag/v3.0.0) uses Node 20
- not urgent

<img width="889" alt="Screen Shot 2024-04-02 at 5 59 37 PM" src="https://github.com/waifuvault/waifuVault-python-api/assets/107364642/f6d5000a-1078-4b44-9a8e-f2e8b184ef86">
